### PR TITLE
Fix: Don't treat dots in words as regexp

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@ function filterDict(rules, excludedWords) {
  * @return {RegExp}
  */
 function getRegExp(word) {
-	const wordPattern = word.replace(/'/g, "['’‘]");
+	const wordPattern = word.replace(/'/g, "['’‘]").replace('.', '\\.');
 	return new RegExp(`(?:^|[^-\\w])(${wordPattern}(?= |\\. |\\.$|$))`, 'ig');
 }
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const fs = require('fs');
 const path = require('path');
 const splitLines = require('split-lines');
 const { RuleHelper } = require('textlint-rule-helper');
-const { differenceWith, isEqual, upperFirst } = require('lodash');
+const { differenceWith, escapeRegExp, isEqual, upperFirst } = require('lodash');
 
 const DEFAULT_OPTIONS = {
 	words: [],
@@ -105,7 +105,7 @@ function filterDict(rules, excludedWords) {
  * @return {RegExp}
  */
 function getRegExp(word) {
-	const wordPattern = word.replace(/'/g, "['’‘]").replace('.', '\\.');
+	const wordPattern = escapeRegExp(word).replace(/'/g, "['’‘]");
 	return new RegExp(`(?:^|[^-\\w])(${wordPattern}(?= |\\. |\\.$|$))`, 'ig');
 }
 

--- a/test.js
+++ b/test.js
@@ -69,6 +69,11 @@ describe('getRegExp', () => {
 		expect(result).toEqual([" a'b", ' a’b', ' a‘b']);
 	});
 
+	it('should not treat words as regexp', () => {
+		const result = getRegExp('i.e.').exec('I have an idea');
+		expect(result).toBeFalsy();
+	});
+
 	it('should match several word', () => {
 		const regexp = getRegExp(word);
 		const text = 'My Java is better than your java';
@@ -164,6 +169,10 @@ tester.run('textlint-rule-stop-words', rule, {
 		{
 			// Should not warn about file names
 			text: 'utilize.md',
+		},
+		{
+			// Should not treat words as regexp
+			text: 'I have an idea',
 		},
 	],
 	invalid: [


### PR DESCRIPTION
I had false positive errors when using the plugin. It was considering the word `idea` as violating the "Don't use `i.e.`" rule.

I could reproduce the issue with tests, and updated the code to fix it. The implementation is a bit naive, as it only escapes dots, but I didn't see any other custom chars in the dictionary.