### PR TITLE
Fix: Exclude words longer than one letter

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const fs = require('fs');
 const path = require('path');
 const splitLines = require('split-lines');
 const { RuleHelper } = require('textlint-rule-helper');
-const { differenceWith, isEqual, upperFirst } = require('lodash');
+const { differenceWith, upperFirst } = require('lodash');
 
 const DEFAULT_OPTIONS = {
 	words: [],
@@ -95,8 +95,12 @@ function parseDict(contents) {
  * @return {Rule[]}
  */
 function filterDict(rules, excludedWords) {
-	const normalizedExcudedWords = excludedWords.map(x => Array.from(x));
-	return differenceWith(rules, normalizedExcudedWords, isEqual);
+	return differenceWith(rules, excludedWords, (rule, word) => {
+		if (Array.isArray(word)) {
+			word = word[0];
+		}
+		return rule[0] === word;
+	});
 }
 
 /**

--- a/test.js
+++ b/test.js
@@ -115,13 +115,13 @@ describe('parseDict', () => {
 
 describe('filterDict', () => {
 	it('should filter array of rules', () => {
-		const result = filterDict([['a'], ['b']], [['a']]);
-		expect(result).toEqual([['b']]);
+		const result = filterDict([['foo'], ['bar']], [['foo']]);
+		expect(result).toEqual([['bar']]);
 	});
 
-	it('should accept strigs for filter instead of arrays', () => {
-		const result = filterDict([['a'], ['b']], ['a']);
-		expect(result).toEqual([['b']]);
+	it('should accept strings for filter instead of arrays', () => {
+		const result = filterDict([['foo'], ['bar']], ['foo']);
+		expect(result).toEqual([['bar']]);
 	});
 });
 


### PR DESCRIPTION
I tried to exclude some words using the syntax defined in the documentation, like this:

```
{
  "stop-words": {
    "exclude": ["relative to"]
  }
}
```

But nothing was excluded. By checking the tests, I realized that tests were only passing for one-letter "words", but failing otherwise. I updated the tests to make them fail (yeah TDD) then updated the code.

I ended up modifying the method to compare the exclude with the word form the dictionary, and only compare to the actual word (not its replacement).

Hope that helps :)