### PR TITLE
Fix condition

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -3,7 +3,7 @@ name: Dependabot Automerge
 jobs:
   worker:
     runs-on: ubuntu-latest
-    if: 'github.actor == "dependabot[bot]"'
+    if: github.actor == 'dependabot[bot]'
     steps:
       - uses: actions/github-script@v3
         with:


### PR DESCRIPTION
@sapegin I noticed that the GitHub Action was failing

> The workflow is not valid. .github/workflows/dependabot.yml (Line: 6, Col: 9): Unexpected symbol: '"dependabot'. Located at position 17 within expression: github.actor == "dependabot[bot]"

https://github.com/sapegin/textlint-rule-stop-words/actions/runs/461592840