### PR TITLE
words need to be declared as Array

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -41,7 +41,7 @@ You can configure the rule in your `.textlintrc`:
       "skip": ["Blockquote"],
       // Extra words
       "words": [
-        ["etc."],
+        ["etc.", "and so on"],
         ["you can"]
       ],
       // Excluded words

--- a/Readme.md
+++ b/Readme.md
@@ -41,8 +41,8 @@ You can configure the rule in your `.textlintrc`:
       "skip": ["Blockquote"],
       // Extra words
       "words": [
-        "etc.",
-        "you can"
+        ["etc."],
+        ["you can"]
       ],
       // Excluded words
       "exclude": [


### PR DESCRIPTION
Not sure if this is intended or not but it won't work as expected if the words are defined as String.
The reason is that we are using the following code:

https://github.com/sapegin/textlint-rule-stop-words/blob/1b0f19fc89c03265abb3e02e42525bdf168387df/index.js#L38

If the rule (ie. the word declared in the `words` property) is an Array then `word` will be the word and `replacement` will be undefined.
But if the is a String then `word` will be the first letter of the word and `replacement` the second letter of the word.